### PR TITLE
Return next(false) and correct content type

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function Throttle () {
             var msg = sprintf(MESSAGE, rate);
             res.writeHead(429, 'application/json');
             res.end('{"error":"' + msg + '"}');
-            return;
+            return next(false);
         }
 
         return next();

--- a/index.js
+++ b/index.js
@@ -74,7 +74,9 @@ function Throttle () {
         if (!bucket.consume(1)) {
             // Until https://github.com/joyent/node/pull/2371 is in
             var msg = sprintf(MESSAGE, rate);
-            res.writeHead(429, 'application/json');
+            res.writeHead(429, {
+                'Content-Type': 'application/json'
+            });
             res.end('{"error":"' + msg + '"}');
             return next(false);
         }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "assert-plus": "~0.1.4",
     "lodash": "~2.0.0",
-    "lru-cache": "~2.3.1"
+    "lru-cache": "~2.3.1",
+    "range_check": "^1.4.0"
   },
   "devDependencies": {
     "async": "~0.2.9",


### PR DESCRIPTION
Instead of `return` return `next(false)` to stop the middleware handler from processing middleware. This will also fire e.g. the http.after event. I use this event to log requests made to my restify api which was not logging throttled requests as it was not fired.

This also fixes the content type header that was not written correctly.